### PR TITLE
Use https URL for git clone. Fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ var copy = function(skeletonPath, rootPath, callback) {
 var clone = function(address, rootPath, callback) {
   var gitHubRe = /(gh|github)\:(?:\/\/)?/;
   var url = gitHubRe.test(address) ?
-    ("git://github.com/" + address.replace(gitHubRe, '') + ".git") : address;
+    ("https://github.com/" + address.replace(gitHubRe, '') + ".git") : address;
   logger.log('Cloning git repo "' + url + '"...');
   exec("git clone " + url + " " + rootPath, function(error, stdout, stderr) {
     if (error != null) {


### PR DESCRIPTION
Forked and edited from an iPhone so commit is untested.
