### PR TITLE
Don't copy-then-delete skeleton's .git directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var exec = require('child_process').exec;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var sysPath = require('path');
-var rimraf = require('rimraf');
 var ncp = require('ncp');
 var os = require('os');
 var crypto = require('crypto');
@@ -134,15 +133,13 @@ var clone = function(address, rootPath, callback) {
   var repoDir = sysPath.join(cacheDir, repoHash);
 
   var copyCached = function() {
-    ncp(repoDir, rootPath, function() {
-      rimraf(sysPath.join(rootPath, '.git'), function(error) {
-        if (error != null) {
-          logger.error("Git dir removal error: " + error.toString());
-        }
-
-        logger.log('Created skeleton directory layout');
-        install(rootPath, callback);
-      });
+    var filter = function(path) {
+      var r = /\.git$/;
+      return !r.test(path);
+    };
+    ncp(repoDir, rootPath, {filter: filter}, function() {
+      logger.log('Created skeleton directory layout');
+      install(rootPath, callback);
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "mkdirp": "~0.5.0",
     "ncp": "^2.0.0",
-    "rimraf": "~2.4.0",
     "hosted-git-info": "~2.1.4",
     "normalize-git-url": "~3.0.1",
     "brunch-skeletons": "~0.1.0"


### PR DESCRIPTION
As it can be the case that the target directory is a git repo already, and that will remove its own .git too (as reported in brunch/brunch#1231).