### PR TITLE
Force colors in outputs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ var brunchSkeletons = require('brunch-skeletons').skeletons;
 var logger = console;
 var commandName = 'init-skeleton';
 
+// Force colors in `exec` outputs
+process.env.FORCE_COLOR = true;
+process.env.NPM_CONFIG_COLOR = 'always';
+
 var skeletons = brunchSkeletons.filter(function(skeleton) {
   return skeleton.alias;
 }).reduce(function(memo, skeleton) {


### PR DESCRIPTION
`child_process.exec()` produce colorless output. I think it would be more friendly when users will see familiar colorful npm's output.

**Before:**

![image](https://cloud.githubusercontent.com/assets/3459374/20759663/391144c4-b726-11e6-9e45-4ff469065794.png)

**After:**

![image](https://cloud.githubusercontent.com/assets/3459374/20759715/634f425e-b726-11e6-9655-6c59bb9be367.png)

We can enforce colors in npm output using `NPM_CONFIG_COLOR` environment variable. `FORCE_COLOR` added because of Bower. Bower uses `chalk`, `chalk` uses `supports-colors` and `supports-colors` checks a `FORCE_COLOR` variable.
